### PR TITLE
fix Respring button not showing up in any case

### DIFF
--- a/ChoicyPrefs/CHPProcessConfigurationListController.m
+++ b/ChoicyPrefs/CHPProcessConfigurationListController.m
@@ -112,11 +112,11 @@
 
 - (void)viewDidLoad
 {
+	[super viewDidLoad];
+
 	if ([_appIdentifier isEqualToString:kSpringboardBundleID]) {
 		self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:localize(@"RESPRING") style:UIBarButtonItemStylePlain target:self action:@selector(respring)];
 	}
-
-	[super viewDidLoad];
 
 	[self updateSwitchesAvailability];
 }


### PR DESCRIPTION
This looks like an empty commit but on iOS16+ I haven’t been able to get the Respring button to show up in any case (SpringBoard daemon settings, SpringBoard pane, etc.)

I wouldn’t be offended if you manually merged this on top of your next commit too